### PR TITLE
fix bug: clear text area doesn't clear tags

### DIFF
--- a/event_code_gui.py
+++ b/event_code_gui.py
@@ -116,6 +116,7 @@ class TextCategorizerApp:
     # 
     def clear_text_area(self):
         self.text_area.delete("1.0", tk.END)
+        self.category_assignments = {}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
reset self.category_assignments = {} when clearing prev transcript